### PR TITLE
Fix typo in documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ rescue => e
 end
 ```
 
-Possible errors to look out for are listed in the [documentation](https://ideal-postcodes.co.uk/documentatpion/response-codes).
+Possible errors to look out for are listed in the [documentation](https://ideal-postcodes.co.uk/documentation/response-codes).
 
 ## Methods
 


### PR DESCRIPTION
The previous link was going to a 404 page.