### PR TITLE
Support Ruby 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: ruby
 before_install:
   - gem update bundler
 rvm:
+  - 2.4.2
   - 2.3.4
   - 2.2.7
   - 2.1.10
   - 2.0.0
-  - 1.9.3

--- a/ideal-postcodes-ruby.gemspec
+++ b/ideal-postcodes-ruby.gemspec
@@ -12,7 +12,7 @@ spec = Gem::Specification.new do |s|
   s.homepage = 'https://ideal-postcodes.co.uk/'
   s.licenses = ['MIT']
 
-  s.add_dependency('rest-client', '~> 1.8')
+  s.add_dependency('rest-client', '>= 1.8', '< 3.0')
 
   s.add_development_dependency 'rake', '~> 10.1'
   s.add_development_dependency 'vcr', '~> 2.9'

--- a/ideal-postcodes-ruby.gemspec
+++ b/ideal-postcodes-ruby.gemspec
@@ -17,7 +17,7 @@ spec = Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 10.1'
   s.add_development_dependency 'vcr', '~> 2.9'
   s.add_development_dependency 'rspec', '~> 3.1'
-  s.add_development_dependency 'webmock', '~> 1.20'
+  s.add_development_dependency 'webmock', '~> 2.3.1'
 
   s.files = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- spec/*`.split("\n")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,8 @@
 # Enable VCR
 require 'vcr'
+require 'webmock'
+
+WebMock.enable!
 
 VCR.configure do |c|
 	c.cassette_library_dir = 'spec/vcr_cassettes'


### PR DESCRIPTION
This PR adds support for Ruby 2.4 and drop support for 1.9.3 (which is already ~2 years [past its EOL](https://www.ruby-lang.org/en/news/2014/01/10/ruby-1-9-3-will-end-on-2015/)).

It also broadens the version specification for the `rest-client` dependency, so that it in turn supports Ruby 2.4 and does not cause Bundler dependency resolution conflicts by being too restrictive (see [stripe gemspec](https://github.com/stripe/stripe-ruby/blob/v1.50.1/stripe.gemspec#L16) as an example).